### PR TITLE
Feature/JMT-44

### DIFF
--- a/src/main/java/com/gdsc/jmt/domain/user/command/UpdateUserNickNameCommand.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/UpdateUserNickNameCommand.java
@@ -1,0 +1,14 @@
+package com.gdsc.jmt.domain.user.command;
+
+import com.gdsc.jmt.global.command.BaseCommand;
+import lombok.Getter;
+
+@Getter
+public class UpdateUserNickNameCommand extends BaseCommand<String> {
+    private final String nickName;
+
+    public UpdateUserNickNameCommand(String id, String nickName) {
+        super(id);
+        this.nickName = nickName;
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/aggregate/UserAggregate.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/aggregate/UserAggregate.java
@@ -2,6 +2,7 @@ package com.gdsc.jmt.domain.user.command.aggregate;
 
 import com.gdsc.jmt.domain.user.command.SignUpCommand;
 import com.gdsc.jmt.domain.user.command.event.CreateUserEvent;
+import com.gdsc.jmt.domain.user.command.event.UpdateUserNickNameEvent;
 import com.gdsc.jmt.domain.user.common.RoleType;
 import com.gdsc.jmt.domain.user.common.SocialType;
 import com.gdsc.jmt.domain.user.common.Status;
@@ -42,5 +43,11 @@ public class UserAggregate {
         this.email = createUserEvent.getEmail();
         this.status = Status.ACTIVE;
         this.socialType = createUserEvent.getSocialType();
+    }
+
+    @EventSourcingHandler
+    public void UpdateUserNickName(UpdateUserNickNameEvent updateUserNickNameEvent) {
+        this.id = updateUserNickNameEvent.getId();
+        this.nickname = updateUserNickNameEvent.getNickName();
     }
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/command/aggregate/UserAggregate.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/aggregate/UserAggregate.java
@@ -1,6 +1,7 @@
 package com.gdsc.jmt.domain.user.command.aggregate;
 
 import com.gdsc.jmt.domain.user.command.SignUpCommand;
+import com.gdsc.jmt.domain.user.command.UpdateUserNickNameCommand;
 import com.gdsc.jmt.domain.user.command.event.CreateUserEvent;
 import com.gdsc.jmt.domain.user.command.event.UpdateUserNickNameEvent;
 import com.gdsc.jmt.domain.user.common.RoleType;
@@ -37,6 +38,14 @@ public class UserAggregate {
         ));
     }
 
+    @CommandHandler
+    public void updateUserNickNameCommand(UpdateUserNickNameCommand updateUserNickNameCommand) {
+        AggregateLifecycle.apply(new UpdateUserNickNameEvent(
+                        updateUserNickNameCommand.getId(),
+                        updateUserNickNameCommand.getNickName()
+        ));
+    }
+
     @EventSourcingHandler
     public void on(CreateUserEvent createUserEvent) {
         this.id = createUserEvent.getId();
@@ -46,7 +55,7 @@ public class UserAggregate {
     }
 
     @EventSourcingHandler
-    public void UpdateUserNickName(UpdateUserNickNameEvent updateUserNickNameEvent) {
+    public void updateUserNickName(UpdateUserNickNameEvent updateUserNickNameEvent) {
         this.id = updateUserNickNameEvent.getId();
         this.nickname = updateUserNickNameEvent.getNickName();
     }

--- a/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.gdsc.jmt.domain.user.command.controller;
+
+import com.gdsc.jmt.domain.user.command.dto.NicknameRequest;
+import com.gdsc.jmt.domain.user.command.dto.response.UserResponse;
+import com.gdsc.jmt.domain.user.command.service.UserService;
+import com.gdsc.jmt.global.controller.FirstVersionRestController;
+import com.gdsc.jmt.global.dto.JMTApiResponse;
+import com.gdsc.jmt.global.jwt.dto.UserInfo;
+import com.gdsc.jmt.global.messege.UserMessage;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "사용자 정보 관련 컨트롤러")
+@FirstVersionRestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/user/nickname")
+    public JMTApiResponse<UserResponse> updateUserNickname(@AuthenticationPrincipal UserInfo user, @RequestBody NicknameRequest nicknameRequest) {
+        userService.updateUserNickName(user.getAggreagatedId(), nicknameRequest.nickname());
+        UserResponse response = new UserResponse(user.getEmail(), nicknameRequest.nickname());
+        return JMTApiResponse.createResponseWithMessage(response, UserMessage.NICKNAME_UPDATE_SUCCESS);
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
 
     @PostMapping("/user/nickname")
     public JMTApiResponse<UserResponse> updateUserNickname(@AuthenticationPrincipal UserInfo user, @RequestBody NicknameRequest nicknameRequest) {
-        userService.updateUserNickName(user.getAggreagatedId(), nicknameRequest.nickname());
+        userService.updateUserNickName(nicknameRequest.userAggregateId(), nicknameRequest.nickname());
         UserResponse response = new UserResponse(user.getEmail(), nicknameRequest.nickname());
         return JMTApiResponse.createResponseWithMessage(response, UserMessage.NICKNAME_UPDATE_SUCCESS);
     }

--- a/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.gdsc.jmt.domain.user.command.controller;
 
+import com.gdsc.jmt.domain.user.command.controller.springdocs.UpdateUserNicknameSpringDocs;
 import com.gdsc.jmt.domain.user.command.dto.NicknameRequest;
 import com.gdsc.jmt.domain.user.command.dto.response.UserResponse;
 import com.gdsc.jmt.domain.user.command.service.UserService;
@@ -20,6 +21,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/user/nickname")
+    @UpdateUserNicknameSpringDocs
     public JMTApiResponse<UserResponse> updateUserNickname(@AuthenticationPrincipal UserInfo user, @RequestBody NicknameRequest nicknameRequest) {
         userService.updateUserNickName(nicknameRequest.userAggregateId(), nicknameRequest.nickname());
         UserResponse response = new UserResponse(user.getEmail(), nicknameRequest.nickname());

--- a/src/main/java/com/gdsc/jmt/domain/user/command/controller/springdocs/UpdateUserNicknameSpringDocs.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/controller/springdocs/UpdateUserNicknameSpringDocs.java
@@ -1,0 +1,28 @@
+package com.gdsc.jmt.domain.user.command.controller.springdocs;
+
+import com.gdsc.jmt.domain.user.command.controller.springdocs.model.ServerErrorException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "닉네임 등록 API", description = "닉네임을 등록하는 API 입니다.")
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+        @ApiResponse(
+                responseCode = "500",
+                description = "알수 없는 서버 에러 발생",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerErrorException.class))
+        )
+
+})
+public @interface UpdateUserNicknameSpringDocs {
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/dto/NicknameRequest.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/dto/NicknameRequest.java
@@ -1,0 +1,4 @@
+package com.gdsc.jmt.domain.user.command.dto;
+
+public record NicknameRequest(String nickname) {
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/dto/NicknameRequest.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/dto/NicknameRequest.java
@@ -1,4 +1,7 @@
 package com.gdsc.jmt.domain.user.command.dto;
 
-public record NicknameRequest(String nickname) {
+public record NicknameRequest(
+        String userAggregateId,
+        String nickname
+) {
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/command/dto/response/UserResponse.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/dto/response/UserResponse.java
@@ -1,0 +1,9 @@
+package com.gdsc.jmt.domain.user.command.dto.response;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UserResponse(
+        String email,
+        String nickname
+) {
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/event/UpdateUserNickNameEvent.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/event/UpdateUserNickNameEvent.java
@@ -1,0 +1,12 @@
+package com.gdsc.jmt.domain.user.command.event;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserNickNameEvent extends BaseUserEvent<String>{
+    private final String nickName;
+    public UpdateUserNickNameEvent(String id, String nickName) {
+        super(id);
+        this.nickName = nickName;
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/service/AuthService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/service/AuthService.java
@@ -11,7 +11,6 @@ import com.gdsc.jmt.domain.user.oauth.info.OAuth2UserInfo;
 import com.gdsc.jmt.domain.user.oauth.info.impl.AppleOAuth2UserInfo;
 import com.gdsc.jmt.domain.user.oauth.info.impl.GoogleOAuth2UserInfo;
 import com.gdsc.jmt.domain.user.apple.AppleUtil;
-import com.gdsc.jmt.domain.user.query.repository.UserRepository;
 import com.gdsc.jmt.global.exception.ApiException;
 import com.gdsc.jmt.global.jwt.TokenProvider;
 import com.gdsc.jmt.global.jwt.dto.TokenResponse;

--- a/src/main/java/com/gdsc/jmt/domain/user/command/service/AuthService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/service/AuthService.java
@@ -45,7 +45,6 @@ public class AuthService {
     private String appleSideGoogleClientId;
     private final TokenProvider tokenProvider;
     private final CommandGateway commandGateway;
-    private UserRepository userRepository;
 
     @Transactional
     public TokenResponse googleLogin(String idToken) {

--- a/src/main/java/com/gdsc/jmt/domain/user/command/service/UserService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/service/UserService.java
@@ -1,0 +1,19 @@
+package com.gdsc.jmt.domain.user.command.service;
+
+import com.gdsc.jmt.domain.user.command.UpdateUserNickNameCommand;
+import lombok.RequiredArgsConstructor;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final CommandGateway commandGateway;
+
+    public void updateUserNickName(String AggregateId, String nickName) {
+        commandGateway.send(new UpdateUserNickNameCommand(
+                AggregateId,
+                nickName
+        ));
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/command/service/UserService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/service/UserService.java
@@ -4,15 +4,17 @@ import com.gdsc.jmt.domain.user.command.UpdateUserNickNameCommand;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final CommandGateway commandGateway;
 
-    public void updateUserNickName(String AggregateId, String nickName) {
+    @Transactional
+    public void updateUserNickName(String userAggregateId, String nickName) {
         commandGateway.send(new UpdateUserNickNameCommand(
-                AggregateId,
+                userAggregateId,
                 nickName
         ));
     }

--- a/src/main/java/com/gdsc/jmt/domain/user/manager/UserQueryEntityManager.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/manager/UserQueryEntityManager.java
@@ -3,8 +3,11 @@ package com.gdsc.jmt.domain.user.manager;
 import com.gdsc.jmt.domain.user.command.aggregate.UserAggregate;
 import com.gdsc.jmt.domain.user.command.event.BaseUserEvent;
 import com.gdsc.jmt.domain.user.command.event.CreateUserEvent;
+import com.gdsc.jmt.domain.user.command.event.UpdateUserNickNameEvent;
 import com.gdsc.jmt.domain.user.query.entity.UserEntity;
 import com.gdsc.jmt.domain.user.query.repository.UserRepository;
+import com.gdsc.jmt.global.exception.ApiException;
+import com.gdsc.jmt.global.messege.UserMessage;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.EventSourcingRepository;
@@ -79,5 +82,17 @@ public class UserQueryEntityManager {
 
     private void persistUser(UserEntity userEntity) {
         userRepository.save(userEntity);
+    }
+
+    @EventSourcingHandler
+    private void updateUserNickname(UpdateUserNickNameEvent updateUserNickNameEvent) {
+        UserAggregate userAggregate = getUserFromEvent(updateUserNickNameEvent);
+        Optional<UserEntity> userEntity = userRepository.findByNickname(userAggregate.nickname);
+        if(userEntity.isPresent()) {
+            throw new ApiException(UserMessage.NICKNAME_IS_DUPLICATED);
+        }
+        UserEntity updateUserEntity = findExistingQueryUserByAggregateId(userAggregate.id);
+        updateUserEntity.setNickname(userAggregate.nickname);
+        persistUser(updateUserEntity);
     }
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/manager/UserQueryEntityManager.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/manager/UserQueryEntityManager.java
@@ -35,13 +35,19 @@ public class UserQueryEntityManager {
     @EventSourcingHandler
     private void updateUserNickName(UpdateUserNickNameEvent updateUserNickNameEvent) {
         UserAggregate userAggregate = getUserFromEvent(updateUserNickNameEvent);
-        Optional<UserEntity> userEntity = userRepository.findByNickname(userAggregate.nickname);
+        checkExistingQueryUserByNickname(userAggregate.nickname);
+
+        UserEntity updateUserEntity = findExistingQueryUserByAggregateId(userAggregate.id);
+        updateUserEntity.setNickname(userAggregate.nickname);
+
+        persistUser(updateUserEntity);
+    }
+
+    private void checkExistingQueryUserByNickname(String nickname) {
+        Optional<UserEntity> userEntity = userRepository.findByNickname(nickname);
         if(userEntity.isPresent()) {
             throw new ApiException(UserMessage.NICKNAME_IS_DUPLICATED);
         }
-        UserEntity updateUserEntity = findExistingQueryUserByAggregateId(userAggregate.id);
-        updateUserEntity.setNickname(userAggregate.nickname);
-        persistUser(updateUserEntity);
     }
 
     @EventSourcingHandler

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
@@ -1,0 +1,28 @@
+package com.gdsc.jmt.domain.user.query.controller;
+
+import com.gdsc.jmt.domain.user.query.controller.springdocs.CheckDuplicateNicknameSpringDocs;
+import com.gdsc.jmt.domain.user.query.service.UserQueryService;
+import com.gdsc.jmt.global.controller.FirstVersionRestController;
+import com.gdsc.jmt.global.dto.JMTApiResponse;
+import com.gdsc.jmt.global.messege.UserMessage;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "사용자 정보 조회 관련 컨트롤러")
+@FirstVersionRestController
+@RequiredArgsConstructor
+public class UserQueryController {
+    private final UserQueryService userQueryService;
+
+    @GetMapping("/user/{nickname}")
+    @CheckDuplicateNicknameSpringDocs
+    public JMTApiResponse<?> checkDuplicateUserNickname(@PathVariable("nickname") String nickname) {
+        boolean isDuplicated = userQueryService.checkDuplicateUserNickname(nickname);
+        if (isDuplicated) {
+            return JMTApiResponse.createResponseWithMessage(null, UserMessage.NICKNAME_IS_DUPLICATED);
+        }
+        return JMTApiResponse.createResponseWithMessage(nickname, UserMessage.NICKNAME_IS_AVAILABLE);
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/CheckDuplicateNicknameSpringDocs.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/CheckDuplicateNicknameSpringDocs.java
@@ -1,0 +1,30 @@
+package com.gdsc.jmt.domain.user.query.controller.springdocs;
+
+import com.gdsc.jmt.domain.user.command.controller.springdocs.model.ServerErrorException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "닉네임 중복 확인 API", description = "닉네임을 등록하기 전에 등록 가능한 닉네임인지 확인하는 API 입니다.")
+@Parameter(name = "nickname", description = "닉네임", required = true)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
+        @ApiResponse(
+                responseCode = "500",
+                description = "알수 없는 서버 에러 발생",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerErrorException.class))
+        )
+
+})
+
+public @interface CheckDuplicateNicknameSpringDocs {
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/query/entity/UserEntity.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/entity/UserEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @Setter
@@ -24,7 +23,8 @@ public class UserEntity extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String email;
     private String profileImageUrl;
-    @Nullable @UniqueElements
+    @Nullable
+    @Column(unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gdsc/jmt/domain/user/query/entity/UserEntity.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/entity/UserEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @Setter
@@ -23,7 +24,7 @@ public class UserEntity extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String email;
     private String profileImageUrl;
-    @Nullable
+    @Nullable @UniqueElements
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gdsc/jmt/domain/user/query/repository/UserRepository.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserAggregateId(String id);
 
     Optional<UserEntity> findByEmail(String email);
+
+    Optional<UserEntity> findByNickname(String nickname);
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
@@ -1,0 +1,21 @@
+package com.gdsc.jmt.domain.user.query.service;
+
+import com.gdsc.jmt.domain.user.query.entity.UserEntity;
+import com.gdsc.jmt.domain.user.query.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+    private final UserRepository userRepository;
+
+    public boolean checkDuplicateUserNickname(String nickname) {
+        Optional<UserEntity> userEntity = userRepository.findByNickname(nickname);
+        if(userEntity.isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
@@ -13,9 +13,6 @@ public class UserQueryService {
 
     public boolean checkDuplicateUserNickname(String nickname) {
         Optional<UserEntity> userEntity = userRepository.findByNickname(nickname);
-        if(userEntity.isEmpty()) {
-            return false;
-        }
-        return true;
+        return userEntity.isPresent();
     }
 }

--- a/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
+++ b/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
@@ -14,7 +14,8 @@ public enum UserMessage implements ResponseMessage{
     REISSUE_SUCCESS("토큰 재발급에 성공하였습니다.", HttpStatus.CREATED),
     REFRESH_TOKEN_INVALID("RefreshToken이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공하였습니다.", HttpStatus.OK),
-    NICKNAME_IS_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT);
+    NICKNAME_IS_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    NICKNAME_IS_AVAILABLE("사용 가능한 닉네임입니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
+++ b/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
@@ -12,7 +12,9 @@ public enum UserMessage implements ResponseMessage{
     LOGIN_SUCCESS("로그인에 성공했습니다.", HttpStatus.OK),
     LOGOUT_SUCCESS("로그아웃에 성공했습니다.", HttpStatus.OK),
     REISSUE_SUCCESS("토큰 재발급에 성공하였습니다.", HttpStatus.CREATED),
-    REFRESH_TOKEN_INVALID("RefreshToken이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+    REFRESH_TOKEN_INVALID("RefreshToken이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공하였습니다.", HttpStatus.OK),
+    NICKNAME_IS_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/com/gdsc/jmt/domain/user/command/UpdateUserNickNameCommandTest.java
+++ b/src/test/java/com/gdsc/jmt/domain/user/command/UpdateUserNickNameCommandTest.java
@@ -1,0 +1,35 @@
+package com.gdsc.jmt.domain.user.command;
+
+import com.gdsc.jmt.domain.user.command.aggregate.UserAggregate;
+import lombok.RequiredArgsConstructor;
+import org.axonframework.test.aggregate.AggregateTestFixture;
+import org.axonframework.test.aggregate.FixtureConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@RequiredArgsConstructor
+@ActiveProfiles("dev")
+class UpdateUserNickNameCommandTest {
+
+    private FixtureConfiguration<UserAggregate> fixture;
+
+    @BeforeEach
+    public void setUp() {
+        fixture = new AggregateTestFixture<>(UserAggregate.class);
+    }
+
+    @Test
+    @WithUserDetails(value = "example2@google.com")
+    public void 유저_닉네임_등록_COMMAND_TEST() {
+        //given
+
+        //when
+
+        //then
+
+    }
+}


### PR DESCRIPTION
## 백로그 링크
- [JMT-44 | 백로그 제목](https://junhyeokjeong.atlassian.net/browse/JMT-44)

## 작업한 내용
- [x] 닉네임 중복 확인 API 작성
- [x] 닉네임 등록 API 작성

## 이슈
- 사용자가 로그인을 할 때마다 AggregateID가 바뀌는 것 확인. Request에 AggregateID 넣는 방식으로 변경
- 추가적으로 AggregateId를 받을 수 있는 API 생성 혹은 다른 방법이 있다면 변경해야 함.