### PR TITLE
Feature/JMT-48 유저 데이터 조회 API 구현

### DIFF
--- a/src/main/java/com/gdsc/jmt/domain/restaurant/query/controller/springdocs/FindRestaurantLocationSpringDocs.java
+++ b/src/main/java/com/gdsc/jmt/domain/restaurant/query/controller/springdocs/FindRestaurantLocationSpringDocs.java
@@ -1,6 +1,7 @@
 package com.gdsc.jmt.domain.restaurant.query.controller.springdocs;
 
 import com.gdsc.jmt.global.controller.springdocs.ServerErrorException;
+import com.gdsc.jmt.global.controller.springdocs.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,11 +18,6 @@ import java.lang.annotation.Target;
 @Operation(summary = "맛집 위치 정보 조회 API", description = "카카오 검색 API를 사용하여 맛집 위치 정보를 조회합니다.")
 @ApiResponses(value = {
         @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
-        @ApiResponse(
-                responseCode = "404",
-                description = "유저 정보를 찾을 수 없습니다.",
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserNotFoundException.class)
-        )
         @ApiResponse(
                 responseCode = "500",
                 description = "알수 없는 서버 에러 발생",

--- a/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/controller/UserController.java
@@ -4,7 +4,7 @@ import com.gdsc.jmt.domain.user.command.controller.springdocs.UpdateUserNickname
 import com.gdsc.jmt.domain.user.command.controller.springdocs.UpdateUserProfileImgSpringDocs;
 import com.gdsc.jmt.domain.user.command.dto.NicknameRequest;
 import com.gdsc.jmt.domain.user.command.dto.ProfileImgRequest;
-import com.gdsc.jmt.domain.user.command.dto.response.UserResponse;
+import com.gdsc.jmt.domain.user.command.dto.response.UserNicknameResponse;
 import com.gdsc.jmt.domain.user.command.service.UserService;
 import com.gdsc.jmt.global.controller.FirstVersionRestController;
 import com.gdsc.jmt.global.dto.JMTApiResponse;
@@ -26,9 +26,9 @@ public class UserController {
 
     @PostMapping("/user/nickname")
     @UpdateUserNicknameSpringDocs
-    public JMTApiResponse<UserResponse> updateUserNickname(@AuthenticationPrincipal UserInfo user, @RequestBody NicknameRequest nicknameRequest) {
+    public JMTApiResponse<UserNicknameResponse> updateUserNickname(@AuthenticationPrincipal UserInfo user, @RequestBody NicknameRequest nicknameRequest) {
         userService.updateUserNickName(nicknameRequest.userAggregateId(), nicknameRequest.nickname());
-        UserResponse response = new UserResponse(user.getEmail(), nicknameRequest.nickname());
+        UserNicknameResponse response = new UserNicknameResponse(user.getEmail(), nicknameRequest.nickname());
         return JMTApiResponse.createResponseWithMessage(response, UserMessage.NICKNAME_UPDATE_SUCCESS);
     }
 

--- a/src/main/java/com/gdsc/jmt/domain/user/command/dto/response/UserNicknameResponse.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/command/dto/response/UserNicknameResponse.java
@@ -1,0 +1,8 @@
+package com.gdsc.jmt.domain.user.command.dto.response;
+
+
+public record UserNicknameResponse(
+        String email,
+        String nickname
+) {
+}

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
@@ -1,6 +1,7 @@
 package com.gdsc.jmt.domain.user.query.controller;
 
 import com.gdsc.jmt.domain.user.query.controller.springdocs.CheckDuplicateNicknameSpringDocs;
+import com.gdsc.jmt.domain.user.query.controller.springdocs.GetUserInfoSpringDocs;
 import com.gdsc.jmt.domain.user.query.dto.UserResponse;
 import com.gdsc.jmt.domain.user.query.service.UserQueryService;
 import com.gdsc.jmt.global.controller.FirstVersionRestController;
@@ -30,6 +31,7 @@ public class UserQueryController {
     }
 
     @GetMapping("/user/info")
+    @GetUserInfoSpringDocs
     public JMTApiResponse<UserResponse> getUserInfo(@AuthenticationPrincipal UserInfo user) {
         UserResponse userInfo = userQueryService.getUserInfo(user.getAggreagatedId());
         return JMTApiResponse.createResponseWithMessage(userInfo, UserMessage.GET_USER_SUCCESS);

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/UserQueryController.java
@@ -1,12 +1,15 @@
 package com.gdsc.jmt.domain.user.query.controller;
 
 import com.gdsc.jmt.domain.user.query.controller.springdocs.CheckDuplicateNicknameSpringDocs;
+import com.gdsc.jmt.domain.user.query.dto.UserResponse;
 import com.gdsc.jmt.domain.user.query.service.UserQueryService;
 import com.gdsc.jmt.global.controller.FirstVersionRestController;
 import com.gdsc.jmt.global.dto.JMTApiResponse;
+import com.gdsc.jmt.global.jwt.dto.UserInfo;
 import com.gdsc.jmt.global.messege.UserMessage;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -24,5 +27,11 @@ public class UserQueryController {
             return JMTApiResponse.createResponseWithMessage(null, UserMessage.NICKNAME_IS_DUPLICATED);
         }
         return JMTApiResponse.createResponseWithMessage(nickname, UserMessage.NICKNAME_IS_AVAILABLE);
+    }
+
+    @GetMapping("/user/info")
+    public JMTApiResponse<UserResponse> getUserInfo(@AuthenticationPrincipal UserInfo user) {
+        UserResponse userInfo = userQueryService.getUserInfo(user.getAggreagatedId());
+        return JMTApiResponse.createResponseWithMessage(userInfo, UserMessage.GET_USER_SUCCESS);
     }
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/GetUserInfoSpringDocs.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/GetUserInfoSpringDocs.java
@@ -1,8 +1,8 @@
 package com.gdsc.jmt.domain.user.query.controller.springdocs;
 
 import com.gdsc.jmt.global.controller.springdocs.ServerErrorException;
+import com.gdsc.jmt.global.controller.springdocs.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,21 +14,19 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Operation(summary = "닉네임 중복 확인 API", description = "닉네임을 등록하기 전에 등록 가능한 닉네임인지 확인하는 API 입니다.")
-@Parameter(name = "nickname", description = "닉네임", required = true)
+@Operation(summary = "로그인된 정보 조회 API", description = "현재 로그인 되어있는 사용자의 정보를 조회합니다.")
 @ApiResponses(value = {
         @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
         @ApiResponse(
                 responseCode = "404",
-                description = "이미 존재하는 닉네임 입니다.",
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = NicknameConflictErrorException.class))
+                description = "유저 정보를 찾을 수 없습니다.",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserNotFoundException.class))
         ),
         @ApiResponse(
                 responseCode = "500",
                 description = "알수 없는 서버 에러 발생",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerErrorException.class))
         )
-
 })
-public @interface getUserInfoSpringDocs {
+public @interface GetUserInfoSpringDocs {
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/getUserInfoSpringDocs.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/controller/springdocs/getUserInfoSpringDocs.java
@@ -1,12 +1,12 @@
-package com.gdsc.jmt.domain.restaurant.query.controller.springdocs;
+package com.gdsc.jmt.domain.user.query.controller.springdocs;
 
 import com.gdsc.jmt.global.controller.springdocs.ServerErrorException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,19 +14,21 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Operation(summary = "맛집 위치 정보 조회 API", description = "카카오 검색 API를 사용하여 맛집 위치 정보를 조회합니다.")
+@Operation(summary = "닉네임 중복 확인 API", description = "닉네임을 등록하기 전에 등록 가능한 닉네임인지 확인하는 API 입니다.")
+@Parameter(name = "nickname", description = "닉네임", required = true)
 @ApiResponses(value = {
         @ApiResponse(responseCode = "200", useReturnTypeSchema = true),
         @ApiResponse(
                 responseCode = "404",
-                description = "유저 정보를 찾을 수 없습니다.",
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserNotFoundException.class)
-        )
+                description = "이미 존재하는 닉네임 입니다.",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = NicknameConflictErrorException.class))
+        ),
         @ApiResponse(
                 responseCode = "500",
                 description = "알수 없는 서버 에러 발생",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerErrorException.class))
         )
+
 })
-public @interface FindRestaurantLocationSpringDocs {
+public @interface getUserInfoSpringDocs {
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/query/dto/UserResponse.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/dto/UserResponse.java
@@ -1,9 +1,9 @@
-package com.gdsc.jmt.domain.user.command.dto.response;
+package com.gdsc.jmt.domain.user.query.dto;
 
 import org.springframework.web.multipart.MultipartFile;
 
 public record UserResponse(
         String email,
-        String nickname
-) {
+        String nickname,
+        String profileImg ) {
 }

--- a/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
+++ b/src/main/java/com/gdsc/jmt/domain/user/query/service/UserQueryService.java
@@ -1,10 +1,18 @@
 package com.gdsc.jmt.domain.user.query.service;
 
+import com.gdsc.jmt.domain.user.command.aggregate.UserAggregate;
+import com.gdsc.jmt.domain.user.query.dto.UserResponse;
 import com.gdsc.jmt.domain.user.query.entity.UserEntity;
 import com.gdsc.jmt.domain.user.query.repository.UserRepository;
+import com.gdsc.jmt.global.exception.ApiException;
+import com.gdsc.jmt.global.messege.UserMessage;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +22,17 @@ public class UserQueryService {
     public boolean checkDuplicateUserNickname(String nickname) {
         Optional<UserEntity> userEntity = userRepository.findByNickname(nickname);
         return userEntity.isPresent();
+    }
+
+    public UserResponse getUserInfo(String userAggregateId) {
+        UserEntity user =  userRepository.findByUserAggregateId(userAggregateId)
+                .orElseThrow(() -> new ApiException(UserMessage.USER_NOT_FOUND));
+
+        return new UserResponse(user.getEmail(), user.getNickname(), getProfileImg(user.getProfileImageUrl()));
+    }
+
+    private String getProfileImg(String profileImgUrl) {
+        Path path = Paths.get("");
+        return path.toAbsolutePath() + profileImgUrl;
     }
 }

--- a/src/main/java/com/gdsc/jmt/global/controller/springdocs/UserNotFoundException.java
+++ b/src/main/java/com/gdsc/jmt/global/controller/springdocs/UserNotFoundException.java
@@ -2,7 +2,9 @@ package com.gdsc.jmt.global.controller.springdocs;
 
 import com.gdsc.jmt.global.messege.UserMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
+@Getter
 public class UserNotFoundException {
     @Schema(description = "", nullable = true)
     String data = null;

--- a/src/main/java/com/gdsc/jmt/global/controller/springdocs/UserNotFoundException.java
+++ b/src/main/java/com/gdsc/jmt/global/controller/springdocs/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.gdsc.jmt.global.controller.springdocs;
+
+import com.gdsc.jmt.global.messege.UserMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class UserNotFoundException {
+    @Schema(description = "", nullable = true)
+    String data = null;
+
+    @Schema(description = "", example = "user 정보를 찾을 수 없습니다.")
+    String message = UserMessage.USER_NOT_FOUND.getMessage();
+
+    @Schema(description = "", example = "USER_NOT_FOUND")
+    String code = UserMessage.USER_NOT_FOUND.toString();
+}

--- a/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
+++ b/src/main/java/com/gdsc/jmt/global/messege/UserMessage.java
@@ -17,7 +17,8 @@ public enum UserMessage implements ResponseMessage{
     NICKNAME_IS_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
     NICKNAME_IS_AVAILABLE("사용 가능한 닉네임입니다.", HttpStatus.OK),
     PROFILE_IMAGE_UPDATE_SUCCESS("프로필 사진 등록에 성공하였습니다.", HttpStatus.OK),
-    PROFILE_IMAGE_UPLOAD_FAIL("프로필 사진 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    PROFILE_IMAGE_UPLOAD_FAIL("프로필 사진 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    GET_USER_SUCCESS("사용자 정보 조회에 성공하였습니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
## 백로그 링크
- [JMT-48 | 백로그 제목](https://junhyeokjeong.atlassian.net/browse/JMT-48)

## 작업한 내용
- [x] 유저 데이터 조회 API 구현

## 이슈
- 현재 이미지 폴더가 프로젝트 파일 내부에 있는데, 보안상의 문제로 프로젝트 내부에 있으면 조회가 안될 수도 있다고 함. 추후 이미지 스토리지 확정되면 수정 예정